### PR TITLE
LoginFragment: route non-auth URLs out of the WebView

### DIFF
--- a/app/src/main/java/org/commonvoice/saverio/ui/login/LoginFragment.kt
+++ b/app/src/main/java/org/commonvoice/saverio/ui/login/LoginFragment.kt
@@ -1,5 +1,6 @@
 package org.commonvoice.saverio.ui.login
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
@@ -8,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
@@ -146,6 +148,27 @@ class LoginFragment : ViewBoundFragment<FragmentLoginBinding>() {
         settings.userAgentString = settings.userAgentString.replace("; wv", "")
 
         webViewClient = object : WebViewClient() {
+
+            override fun shouldOverrideUrlLoading(
+                view: WebView?,
+                request: WebResourceRequest?
+            ): Boolean {
+                val uri = request?.url ?: return false
+                val host = uri.host
+                val isAuthHost = host == "commonvoice.mozilla.org"
+                    || host == "auth.mozilla.auth0.com"
+                    || host?.endsWith(".mozilla.org") == true
+                    || host?.endsWith(".auth0.com") == true
+                if (isAuthHost && (uri.scheme == "https" || uri.scheme == "http")) {
+                    return false
+                }
+                try {
+                    startActivity(Intent(Intent.ACTION_VIEW, uri))
+                } catch (e: ActivityNotFoundException) {
+                    Timber.w(e, "No activity to handle %s", uri)
+                }
+                return true
+            }
 
             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                 showLoading()


### PR DESCRIPTION
Closes #220.

`LoginFragment.setupWebBrowser` only overrode `onPageStarted` / `onPageFinished`, so any link the auth pages or Common Voice landing page rendered (privacy/terms/contact, `mailto:`, off-host stuff) loaded inside the login WebView. That breaks the cookie pickup in `onPageFinished` and traps the user on a side page.

### Change

Add `shouldOverrideUrlLoading`. Keep the WebView pinned to the hosts the OAuth flow actually uses (`commonvoice.mozilla.org`, `auth.mozilla.auth0.com`, plus `*.mozilla.org` / `*.auth0.com` for redirect hops). Hand any other URL to `Intent.ACTION_VIEW` via the system, wrapped in `try/catch(ActivityNotFoundException)` so an unhandled scheme cannot crash the fragment.

The success path (Common Voice -> Auth0 -> Common Voice with `connect.sid`) is unchanged. Imports for `ActivityNotFoundException` and `WebResourceRequest` are added.